### PR TITLE
feat: Add onAnimationComplete prop to modal

### DIFF
--- a/src/widgets/Modal/Modal.tsx
+++ b/src/widgets/Modal/Modal.tsx
@@ -15,6 +15,7 @@ const Modal: React.FC<ModalProps> = ({
   zIndex = "modal",
   minWidth = "50%",
   maxWidth = "80%",
+  onAnimationComplete,
   ...props
 }) => {
   return (
@@ -28,6 +29,7 @@ const Modal: React.FC<ModalProps> = ({
             exit={{ opacity: 0, transform: "translate(-50%, -50%) scale(0)" }}
             {...props}
             sx={{ minWidth, maxWidth, zIndex, ...style.container }}
+            onAnimationComplete={onAnimationComplete}
           >
             {title && (
               <ModalHeader onDismiss={onDismiss}>

--- a/src/widgets/Modal/types.ts
+++ b/src/widgets/Modal/types.ts
@@ -1,5 +1,6 @@
 export interface InternalProps {
   onDismiss?: () => void;
+  onAnimationComplete?: () => void;
   t?: (key: string) => string;
 }
 


### PR DESCRIPTION
Sometimes we want to make some changes when the modal animation completes, this PR adds a prop that accepts a function and calls it when the modal animation completes.