### PR TITLE
generic cleanups and bug fixes

### DIFF
--- a/src/__tests__/components/toggle.test.tsx
+++ b/src/__tests__/components/toggle.test.tsx
@@ -30,7 +30,7 @@ it("renders correctly", () => {
           </span>
         </div>
         <button
-          class="css-1uj2es5"
+          class="css-1iz1aqp-Toggle"
         >
           Switch2 
         </button>

--- a/src/__tests__/widgets/menu.test.tsx
+++ b/src/__tests__/widgets/menu.test.tsx
@@ -167,7 +167,7 @@ it("renders correctly", () => {
           >
             <div>
               <button
-                class="css-1kusgwj"
+                class="css-10odqte"
                 font-size="14px"
               >
                 <span
@@ -180,7 +180,7 @@ it("renders correctly", () => {
             </div>
             <button
               aria-label="Toggle menu"
-              class="css-cnncwg"
+              class="css-1u0toul"
             >
               <svg
                 class="sc-gsTEea fQWPxo"
@@ -485,7 +485,7 @@ it("renders correctly", () => {
                     </svg>
                   </div>
                   <button
-                    class="css-1erqard"
+                    class="css-giy75x"
                   >
                     <svg
                       class="sc-gsTEea fQWPxo"
@@ -685,7 +685,7 @@ it("renders correctly", () => {
                 class="sc-hHfuMS jmzyPq"
               >
                 <button
-                  class="css-c0dbms"
+                  class="css-giy75x"
                 >
                   <div
                     class="css-4cffwv"
@@ -726,7 +726,7 @@ it("renders correctly", () => {
                    
                 </button>
                 <button
-                  class="css-1erqard"
+                  class="css-giy75x"
                 >
                   <svg
                     class="sc-gsTEea fQWPxo"

--- a/src/__tests__/widgets/walletmodal.test.tsx
+++ b/src/__tests__/widgets/walletmodal.test.tsx
@@ -17,7 +17,7 @@ it("renders ConnectModal correctly", () => {
           style="opacity: 0; transform: translate(-50%, -50%) scale(0.1);"
         >
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -156,7 +156,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -196,7 +196,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -308,7 +308,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -333,7 +333,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -360,7 +360,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -391,7 +391,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -432,7 +432,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -493,7 +493,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -536,7 +536,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-6h7fdg"
+            class="css-1fjjhyd"
             id="wallet-connect-"
           >
             <span
@@ -584,7 +584,7 @@ it("renders ConnectModal correctly", () => {
              
           </button>
           <button
-            class="css-1dn8hyl"
+            class="css-rtl4ff"
             id="wallet-connect-"
           >
             <span
@@ -616,7 +616,7 @@ it("renders ConnectModal correctly", () => {
             class="css-1gksbu2"
           >
             <a
-              class="css-10ylzz7"
+              class="css-1n3itcm"
               href="https://apeswap.gitbook.io/apeswap-finance/product-and-features/wallets/how-to-connect-your-wallet"
               rel="noreferrer noopener"
               target="_blank"
@@ -678,7 +678,7 @@ it("renders AccountModal correctly", () => {
             class="css-1ne87w5"
           >
             <a
-              class="css-f7lsuy"
+              class="css-1i0376m"
               href="https://bscscan.com/address/undefined"
               rel="noreferrer noopener"
               target="_blank"

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -9,7 +9,7 @@ import { AlertProps, variants } from "./types";
 import { LinkExternal } from "../Link";
 import { Svg } from "../Svg";
 
-const Alert: React.FC<AlertProps> = ({ variant = variants.ERROR, text, linkText, url, size, onClose }) => {
+const Alert: React.FC<AlertProps> = ({ variant = variants.ERROR, text, linkText, url, size, onClose, ...props }) => {
   return (
     <motion.div
       initial={{ right: "-250px" }}
@@ -17,6 +17,7 @@ const Alert: React.FC<AlertProps> = ({ variant = variants.ERROR, text, linkText,
       transition={{ duration: 0.5 }}
       exit={{ right: "-250px" }}
       sx={styles.alert}
+      {...props}
     >
       <Flex>
         <Svg

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,8 +5,6 @@ import { ButtonProps, variants, buttonFontSizes, buttonPadding, sizes } from "./
 
 const Button: React.FC<ButtonProps> = ({
   variant = variants.PRIMARY,
-  sx,
-  csx,
   size = sizes.MEDIUM,
   load,
   children,
@@ -82,8 +80,6 @@ const Button: React.FC<ButtonProps> = ({
         },
         ...hoverStyle,
         width: fullWidth ? "100%" : "max-content",
-        ...sx,
-        ...csx,
       }}
     >
       {React.isValidElement(startIcon) &&

--- a/src/components/Button/IconButton.tsx
+++ b/src/components/Button/IconButton.tsx
@@ -12,7 +12,6 @@ const IconButton: React.FC<IconButtonProps> = ({
   background = colorValues.yellow,
   variant = variants.PRIMARY,
   children,
-  sx,
   ...props
 }) => {
   return (
@@ -24,7 +23,6 @@ const IconButton: React.FC<IconButtonProps> = ({
         background,
         ...(variant === variants.PRIMARY ? style.primary : {}),
         ...(variant === variants.TRANSPARENT ? style.transparent : {}),
-        ...sx,
       }}
     >
       {children || <Svg color={color} icon={icon} {...props} />}

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -48,7 +48,6 @@ export interface ButtonProps extends ThemeUIButtonProps {
   startIcon?: ReactNode;
   endIcon?: ReactNode;
   fullWidth?: boolean;
-  csx?: ThemeUICSSObject;
   load?: boolean;
   [key: string]: any;
 }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { Card as ThemeUICard } from "theme-ui";
 import { CardProps } from "./types";
 
-const Card: React.FC<CardProps> = ({ children, background, sx, ...props }) => {
+const Card: React.FC<CardProps> = ({ children, background, ...props }) => {
   return (
-    <ThemeUICard {...props} sx={{ ...sx, variant: `cards.primary`, background }}>
+    <ThemeUICard {...props} sx={{ variant: `cards.primary`, background }}>
       {children}
     </ThemeUICard>
   );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -12,12 +12,13 @@ const getScale = ({ scale }: CheckboxProps) => {
   }
 };
 
-const Checkbox: React.FC<CheckboxProps> = ({ scale = scales.SM, display = "block", ...props }) => {
+const Checkbox: React.FC<CheckboxProps> = ({ scale = scales.SM, display = "block", className, ...props }) => {
   const scaleSize = getScale({ scale });
   const svgScale = scale === "sm" ? 13 : 21;
 
   return (
     <span
+      className={className}
       sx={{
         display,
         width: scaleSize,

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Divider as ThemeUIDivider } from "theme-ui";
 
-const Divider: React.FC = () => {
-  return <ThemeUIDivider sx={{ variant: "styles.hr" }} />;
+const Divider: React.FC = ({ ...props }) => {
+  return <ThemeUIDivider {...props} sx={{ variant: "styles.hr" }} />;
 };
 
 export default Divider;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { DropdownProps, dropdownPadding, fontSizes, sizes } from "./types";
 import { Svg } from "../Svg";
 
-const Dropdown: React.FC<DropdownProps> = ({ component, children, size = sizes.MEDIUM }) => {
+const Dropdown: React.FC<DropdownProps> = ({ component, children, size = sizes.MEDIUM, ...props }) => {
   const [open, setOpen] = useState(false);
 
   const handleClick = () => setOpen((prev) => !prev);
@@ -19,6 +19,7 @@ const Dropdown: React.FC<DropdownProps> = ({ component, children, size = sizes.M
         position: "relative",
       }}
       onClick={handleClick}
+      {...props}
     >
       <Flex
         sx={{

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -17,10 +17,18 @@ const Element: React.FC<DropdownItemProps> = ({ onClick, url, active, size, chil
   );
 };
 
-const DropdownItem: React.FC<DropdownItemProps> = ({ onClick, url, active, size = sizes.MEDIUM, children }) => {
+const DropdownItem: React.FC<DropdownItemProps> = ({
+  onClick,
+  url,
+  active,
+  size = sizes.MEDIUM,
+  children,
+  ...props
+}) => {
   return (
     <Box
       as="li"
+      {...props}
       sx={{
         px: dropdownItemPadding[size].x,
         py: dropdownItemPadding[size].y,

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { Heading as ThemeUIHeading } from "theme-ui";
 import { HeadingProps } from "./types";
 
-const Heading: React.FC<HeadingProps> = ({ children, as = "h3", banner }) => {
+const Heading: React.FC<HeadingProps> = ({ children, as = "h3", banner, ...props }) => {
   return (
-    <ThemeUIHeading as={as} sx={{ variant: `styles.${banner ? "banner" : as || "h1"}` }}>
+    <ThemeUIHeading {...props} as={as} sx={{ variant: `styles.${banner ? "banner" : as || "h1"}` }}>
       {children}
     </ThemeUIHeading>
   );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -20,7 +20,6 @@ const Input: React.FC<InputProps> = ({ size = sizes.MD, icon, width, sx, ...prop
           variant: `forms.input.${size}`,
           color: "text",
           outline: "none",
-          ...sx,
         }}
       />
       {icon && (

--- a/src/components/Link/LinkExternal.tsx
+++ b/src/components/Link/LinkExternal.tsx
@@ -4,7 +4,7 @@ import { Box, Link } from "theme-ui";
 import { Svg } from "../Svg";
 import { LinkExternalProps } from "./types";
 
-const LinkExternal: React.FC<LinkExternalProps> = ({ display, textAlign, children, sx, ...props }) => {
+const LinkExternal: React.FC<LinkExternalProps> = ({ display, textAlign, children, ...props }) => {
   return (
     <Link
       sx={{
@@ -13,7 +13,6 @@ const LinkExternal: React.FC<LinkExternalProps> = ({ display, textAlign, childre
         textAlign,
         cursor: "pointer",
         alignItems: "center",
-        ...sx,
       }}
       {...props}
       target="_blank"

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -14,6 +14,7 @@ const Progress: React.FC<ProgressProps> = ({
   color = "gradient",
   background = "white4",
   width = "100%",
+  ...props
 }) => {
   const [toValue, setTo] = useState(0);
 
@@ -23,6 +24,7 @@ const Progress: React.FC<ProgressProps> = ({
 
   return (
     <div
+      {...props}
       sx={{
         height,
         width,

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -22,12 +22,12 @@ const getCheckedScale = ({ scale }: RadioProps) => {
   }
 };
 
-const Radio: React.FC<RadioProps> = ({ scale = scales.SM, display = "inline-block", ...props }) => {
+const Radio: React.FC<RadioProps> = ({ scale = scales.SM, display = "inline-block", className, ...props }) => {
   const scaleSize = getScale({ scale });
   const checkedScale = getCheckedScale({ scale });
 
   return (
-    <span sx={{ display, width: scaleSize, height: scaleSize, position: "relative" }}>
+    <span className={className} sx={{ display, width: scaleSize, height: scaleSize, position: "relative" }}>
       <input type="radio" sx={{ variant: "forms.radio" }} {...props} />
       <span sx={{ width: checkedScale, height: checkedScale }} />
     </span>

--- a/src/components/Select/SelectItem.tsx
+++ b/src/components/Select/SelectItem.tsx
@@ -4,12 +4,13 @@ import { Box } from "theme-ui";
 import { SelectItemProps, selectItemPadding, sizes } from "./types";
 import { dynamicStyles } from "./styles";
 
-const SelectItem: React.FC<SelectItemProps> = ({ onClick, value, active, size = sizes.MEDIUM, children }) => {
+const SelectItem: React.FC<SelectItemProps> = ({ onClick, value, active, size = sizes.MEDIUM, children, ...props }) => {
   const style = dynamicStyles.dropdownItem({ size });
 
   return (
     <Box
       as="li"
+      {...props}
       onClick={() => onClick?.(value)}
       sx={{
         padding: selectItemPadding[size],

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource theme-ui */
 import React from "react";
 
-const Table: React.FC = ({ children }) => {
+const Table: React.FC = ({ children, ...props }) => {
   return (
     <table
+      {...props}
       sx={{
         width: "100%",
       }}

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -2,9 +2,10 @@
 import React from "react";
 import { TableBodyProps } from "./types";
 
-const TableBody: React.FC<TableBodyProps> = ({ children, borderRadius }) => {
+const TableBody: React.FC<TableBodyProps> = ({ children, borderRadius, ...props }) => {
   return (
     <tbody
+      {...props}
       sx={{
         tr: {
           "&:nth-child(odd) td": {

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource theme-ui */
 import React from "react";
 
-const TableCell: React.FC = ({ children }) => {
+const TableCell: React.FC = ({ children, ...props }) => {
   return (
     <td
+      {...props}
       sx={{
         px: 4,
         py: 2,

--- a/src/components/Table/TableHead.tsx
+++ b/src/components/Table/TableHead.tsx
@@ -2,9 +2,10 @@
 import React from "react";
 import { TableHeadProps } from "./types";
 
-const TableHead: React.FC<TableHeadProps> = ({ children, width }) => {
+const TableHead: React.FC<TableHeadProps> = ({ children, width, ...props }) => {
   return (
     <th
+      {...props}
       sx={{
         px: 4,
         py: 2,

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -2,9 +2,10 @@
 import React from "react";
 import { TableRowProps } from "./types";
 
-const TableRow: React.FC<TableRowProps> = ({ children, textAlign = "center" }) => {
+const TableRow: React.FC<TableRowProps> = ({ children, textAlign = "center", ...props }) => {
   return (
     <tr
+      {...props}
       sx={{
         textAlign,
       }}

--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -2,8 +2,12 @@ import React from "react";
 import { Box } from "theme-ui";
 import { TabPanelProps } from "./types";
 
-const TabPanel: React.FC<TabPanelProps> = ({ children, index, activeTab }) => {
-  return activeTab === index ? <Box sx={{ pt: 8 }}>{children}</Box> : null;
+const TabPanel: React.FC<TabPanelProps> = ({ children, index, activeTab, ...props }) => {
+  return activeTab === index ? (
+    <Box {...props} sx={{ pt: 8 }}>
+      {children}
+    </Box>
+  ) : null;
 };
 
 export default TabPanel;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource theme-ui */
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { Box } from "theme-ui";
 import { Button } from "../Button";
@@ -6,7 +7,13 @@ import styles from "./styles";
 
 const isBrowser = typeof window === "object";
 
-const Tabs: React.FC<TabsProps> = ({ activeTab = 0, children, variant = variants.CENTERED, size = sizes.MEDIUM }) => {
+const Tabs: React.FC<TabsProps> = ({
+  activeTab = 0,
+  children,
+  variant = variants.CENTERED,
+  size = sizes.MEDIUM,
+  ...props
+}) => {
   const [label, setLabel] = useState<string>();
   const activeRef = useRef<any>(null);
   const [activeStyle, setActiveStyle] = useState({});
@@ -33,6 +40,7 @@ const Tabs: React.FC<TabsProps> = ({ activeTab = 0, children, variant = variants
 
   return (
     <Box
+      {...props}
       sx={{
         ...styles.tabs,
         justifyContent: variant === variants.CENTERED ? "center" : null,
@@ -58,16 +66,20 @@ const Tabs: React.FC<TabsProps> = ({ activeTab = 0, children, variant = variants
             ref: (child as any)?.props?.index === activeTab ? activeRef : undefined,
           });
         })}
-        <Button
-          csx={{
-            ...styles.tabButton,
-            ...activeStyle,
-            display: isBrowser ? undefined : "none",
-          }}
-          sx={{ px: tabPadding[size].x, py: tabPadding[size].y, fontSize: fontSizes[size] }}
-        >
-          {label}
-        </Button>
+        {activeTab >= 0 && (
+          <Button
+            sx={{
+              px: tabPadding[size].x,
+              py: tabPadding[size].y,
+              fontSize: fontSizes[size],
+              ...styles.tabButton,
+              ...activeStyle,
+              display: isBrowser ? undefined : "none",
+            }}
+          >
+            {label}
+          </Button>
+        )}
       </Box>
     </Box>
   );

--- a/src/components/Tabs/styles.ts
+++ b/src/components/Tabs/styles.ts
@@ -16,13 +16,10 @@ const styles: Record<string, ThemeUIStyleObject> = {
     margin: 0,
   },
   tabButton: {
-    px: "36px",
-    py: "9px",
     position: "absolute",
     border: 0,
     top: 0,
     height: "100%",
-    fontSize: "14px",
     transition: "left 0.2s linear",
     textTransform: "none",
     "&:hover": {

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Textarea as ThemeUITextarea, TextareaProps } from "theme-ui";
 
-const Textarea: React.FC<TextareaProps> = ({ sx, children, ...props }) => {
+const Textarea: React.FC<TextareaProps> = ({ children, ...props }) => {
   return (
-    <ThemeUITextarea {...props} sx={{ ...sx, variant: "forms.textarea" }}>
+    <ThemeUITextarea {...props} sx={{ variant: "forms.textarea" }}>
       {children}
     </ThemeUITextarea>
   );

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -8,7 +8,7 @@ import styles from "./styles";
 
 const isBrowser = typeof window === "object";
 
-const Toggle: React.FC<ToggleProps> = ({ checked, labels, size = sizes.MEDIUM, ...props }) => {
+const Toggle: React.FC<ToggleProps> = ({ checked, labels, size = sizes.MEDIUM, className, ...props }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const leftRef = useRef<any>(null);
   const rightRef = useRef<any>(null);
@@ -41,7 +41,7 @@ const Toggle: React.FC<ToggleProps> = ({ checked, labels, size = sizes.MEDIUM, .
   };
 
   return (
-    <Box sx={styles.container}>
+    <Box className={className} sx={styles.container}>
       <Box
         ref={leftRef}
         sx={{
@@ -76,7 +76,7 @@ const Toggle: React.FC<ToggleProps> = ({ checked, labels, size = sizes.MEDIUM, .
         </Text>
       </Box>
       <Button
-        csx={{
+        sx={{
           ...styles.button,
           ...activeStyle,
           fontSize: fontSizes[size],

--- a/src/components/Toggle/styles.ts
+++ b/src/components/Toggle/styles.ts
@@ -19,14 +19,12 @@ const styles: Record<string, ThemeUIStyleObject> = {
     },
   },
   button: {
-    px: "14px",
-    py: "9px",
     position: "absolute",
     border: 0,
     top: 0,
     height: "100%",
-    fontSize: "14px",
     transition: "left 0.2s linear",
+    textTransform: "none",
     "&:hover": {
       filter: "none",
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export * from "./widgets/Navbar";
 export * from "./widgets/WalletModal";
 export * from "./widgets/NetworkModal";
 export * from "./widgets/MarketingModal";
+export { default as useLanguageModal } from "./widgets/LanguageModal/useLanguageModal";
 
 // Theme
 export { default as ResetCSS } from "./ResetCSS";

--- a/src/widgets/Modal/Modal.stories.tsx
+++ b/src/widgets/Modal/Modal.stories.tsx
@@ -61,8 +61,8 @@ export const Default = (args: any) => {
       <Button variant="secondary" onClick={() => setOpen(!open)}>
         Show Modal
       </Button>
-      <Modal {...args} open={open} handleClose={() => setOpen(!open)}>
-        <ModalHeader onDismiss={() => setOpen(!open)}>
+      <Modal {...args} open={open} onDismiss={() => setOpen(!open)}>
+        <ModalHeader>
           <Heading as="h3">Stake BANANA</Heading>
         </ModalHeader>
         <div sx={styles.base}>
@@ -78,7 +78,7 @@ export const Default = (args: any) => {
             <Text>Balance: 100.33</Text>
           </div>
         </div>
-        <ModalFooter onDismiss={() => setOpen(!open)}>
+        <ModalFooter>
           <Button>DEPOSIT</Button>
         </ModalFooter>
       </Modal>

--- a/src/widgets/Modal/Modal.tsx
+++ b/src/widgets/Modal/Modal.tsx
@@ -36,7 +36,18 @@ const Modal: React.FC<ModalProps> = ({
                 <Heading>{title}</Heading>
               </ModalHeader>
             )}
-            {children}
+            {React.Children.map(children, (child) => {
+              if (React.isValidElement(child)) {
+                return React.cloneElement(child as any, {
+                  ...(child as any)?.props,
+                  onDismiss: () => {
+                    (child as any)?.props?.onDismiss?.();
+                    onDismiss?.();
+                  },
+                });
+              }
+              return child;
+            })}
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/widgets/Modal/ModalContext.tsx
+++ b/src/widgets/Modal/ModalContext.tsx
@@ -49,6 +49,7 @@ const ModalProvider: React.FC = ({ children }) => {
   };
 
   const handleDismiss = () => {
+    if (React.isValidElement(modalNode)) modalNode.props?.onDismiss?.();
     setModalNode(undefined);
     setIsOpen(false);
     setNodeId("");

--- a/src/widgets/Modal/ModalHeader.tsx
+++ b/src/widgets/Modal/ModalHeader.tsx
@@ -4,19 +4,13 @@ import style from "./styles";
 import { IconButton } from "../../components/Button";
 import { InternalProps } from "./types";
 import { Divider } from "../../components/Divider";
-import { Context as ModalContext } from "./ModalContext";
 
 const ModalHeader: React.FC<InternalProps> = ({ children, onDismiss, ...props }) => {
-  const { handleClose } = useContext(ModalContext);
-  const onClose = () => {
-    onDismiss?.();
-    handleClose();
-  };
   return (
     <>
       <Flex {...props} sx={style.modalHead}>
         {children}
-        <IconButton icon="close" color="text" variant="transparent" onClick={onClose} />
+        <IconButton icon="close" color="text" variant="transparent" onClick={onDismiss} />
       </Flex>
       <Divider />
     </>

--- a/src/widgets/NetworkModal/NetworkCard.tsx
+++ b/src/widgets/NetworkModal/NetworkCard.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource theme-ui */
 import React, { useContext } from "react";
 import { Button } from "../../components/Button";
 import Text from "../../components/Text/Text";
@@ -26,7 +27,7 @@ const NetworkCard: React.FC<Props> = ({ networkConfig, chainId, switchNetwork })
   const { symbol, icon: Icon } = networkConfig;
   return (
     <Button
-      csx={networkBtn}
+      sx={networkBtn}
       size="sm"
       fullWidth
       disabled={chainId === networkConfig.chainId}

--- a/src/widgets/NetworkModal/SelectNetworkModal.tsx
+++ b/src/widgets/NetworkModal/SelectNetworkModal.tsx
@@ -9,10 +9,11 @@ interface Props {
   switchNetwork: SwitchNetwork;
   chainId: number;
   t: (key: string) => string;
+  onDismiss?: () => void;
 }
 
-const SelectNetworkModal: React.FC<Props> = ({ switchNetwork, chainId, t }) => (
-  <Modal maxWidth="350px" minWidth="350px">
+const SelectNetworkModal: React.FC<Props> = ({ switchNetwork, chainId, t, onDismiss }) => (
+  <Modal maxWidth="350px" minWidth="350px" onDismiss={onDismiss}>
     <ModalHeader>
       <Heading as="h4">{t("Network")}</Heading>
     </ModalHeader>
@@ -21,5 +22,9 @@ const SelectNetworkModal: React.FC<Props> = ({ switchNetwork, chainId, t }) => (
     ))}
   </Modal>
 );
+
+SelectNetworkModal.defaultProps = {
+  onDismiss: () => null,
+};
 
 export default SelectNetworkModal;


### PR DESCRIPTION
Removed explicit use of sx props passed to components because it limited our customization options and was not always reliable. The iniatial hack was to introduce `csx` props which have now also been removed. To customize components, we just need to add `/** @jsxImportSource theme-ui */` to the top of the file and the sx props will become available in the component. Any styles applied here gets converted to a className which the component receives through `{...props}`. We can increase the specificity of the css target using double `&&` or tripple `&&&` ampersand if we need to override css styles.

Fixed style errors in tabs and toggle components that caused size mismatch.

Dynamically injected `onDismiss` props to all direct children of `Modal` This way, we don't have to pass onDismiss explicitly all the time.

`Modal` now accepts a cleanup function using the `onDismiss` prop. Any function passed here gets called just before the modal gets closed.