### PR TITLE
Grant #006 - Swap & Liquidity iFrame-UIKit

### DIFF
--- a/src/__tests__/widgets/menu.test.tsx
+++ b/src/__tests__/widgets/menu.test.tsx
@@ -42,6 +42,7 @@ it("renders correctly", () => {
         t={() => ""}
         links={menuConfig}
         runFiat={noop}
+        iframe={false}
       >
         body
       </Navbar>

--- a/src/widgets/Navbar/Navbar.tsx
+++ b/src/widgets/Navbar/Navbar.tsx
@@ -108,6 +108,7 @@ const Navbar: React.FC<NavProps> = ({
   track,
   liveResult,
   runFiat,
+  iframe,
 }) => {
   const { isXxl } = useMatchBreakpoints();
   const isMobile = isXxl === false;
@@ -275,7 +276,8 @@ const Navbar: React.FC<NavProps> = ({
         </Inner>
         <MobileOnlyOverlay show={isPushed} onClick={() => setIsPushed(false)} role="presentation" />
       </BodyWrapper>
-      <Footer
+      {!iframe && 
+        (<Footer
         chainId={chainId}
         track={track}
         toggleTheme={toggleTheme}
@@ -287,7 +289,8 @@ const Navbar: React.FC<NavProps> = ({
         currentLang={currentLang}
         t={t}
         runFiat={runFiat}
-      />
+        />)
+     }
     </Wrapper>
   );
 };

--- a/src/widgets/Navbar/types.ts
+++ b/src/widgets/Navbar/types.ts
@@ -77,4 +77,5 @@ export interface NavProps extends PanelProps {
   liveResult?: LiveResultProps["apiResult"] | undefined;
   t: (text: string) => string;
   runFiat: () => void;
+  iframe: boolean;
 }


### PR DESCRIPTION
@obiedobo 
[Grant #006](https://github.com/ApeSwapFinance/apeswap-frontend/issues/813)

[Gordon](https://discord.com/users/842553249461698572)
Wallet Address:
0x994C5FA754E4370a7EAc140332585FF8009b9ddf

Updated the ApeSwap UIKit to pass an iframe check as a paremeter in order to hide the footer when in an iframe. This is in addition to the frontend pull request for the same grant.

Copy and paste code below into an html file then open it while front end is running. It will display site in an iframe with the header elements and footer hidden.

```
<html>
<body>
TEST
<br/>
<iframe src="http://localhost:3000/orders" width="1500px" height="600px" />
</body>
</html>
```